### PR TITLE
Change decimal precision to 2

### DIFF
--- a/resources/views/livewire/table-info.blade.php
+++ b/resources/views/livewire/table-info.blade.php
@@ -44,7 +44,7 @@
                             </code>
                         </x-pulse::td>
                         <x-pulse::td class="text-gray-700 dark:text-gray-300 font-bold">
-                            {{ \Illuminate\Support\Number::fileSize($result->size ?? 0, maxPrecision: 3) }}
+                            {{ \Illuminate\Support\Number::fileSize($result->size ?? 0, maxPrecision: 2) }}
                         </x-pulse::td>
                         <x-pulse::td class="text-gray-700 dark:text-gray-300 font-bold">
                             {{ $result->rows }}


### PR DESCRIPTION
Hi there, and thank you for this useful package!

I would like to propose changing the `maxPrecision` from 3 to 2 when displaying the table size. Using a precision of 3 is easily confused with thousands of a unit, at first glance. For example, the screenshot on the project README shows tables of 56.109 MB and 9.047 MB, which could be confused for 56109 MB and 9047 MB. 

I think a precision of 2 should be sufficient and would make the card more readable.